### PR TITLE
System GMP and 32 Bits eclipse

### DIFF
--- a/ExtProd/PRODUCTS/download-products.sh
+++ b/ExtProd/PRODUCTS/download-products.sh
@@ -1,14 +1,24 @@
 #!/bin/bash
 
 DOWNLOAD_LIST=extprods.links.txt
-
-for item in `cat $DOWNLOAD_LIST`; do 
-	p=`echo $item |cut -d':' -f1`
-  	if [ $p = "http" ]; then 
-		wget -c -O $PACKAGE_NAME $item 
-	elif [ $p = "https" ]; then
-		wget -c -O $PACKAGE_NAME --no-check-certificate $item
-	else
-		PACKAGE_NAME=$item
-	fi 
+sufix='-x86_64'
+arch=`uname -m`
+for item in `cat $DOWNLOAD_LIST`; do
+        if [[ "$item" == *"eclipse"* ]]
+        then
+                echo $arch
+                if [[ "$arch" == *"i"* ]]
+                then
+                        item=${item/-x86_64/}
+                fi
+        fi
+        p=`echo $item |cut -d':' -f1`
+        if [ $p = "http" ]; then
+                wget -c -O $PACKAGE_NAME $item
+        elif [ $p = "https" ]; then
+                wget -c -O $PACKAGE_NAME --no-check-certificate $item
+        else
+                PACKAGE_NAME=$item
+        fi
 done
+

--- a/ExtProd/PRODUCTS/download-products.sh
+++ b/ExtProd/PRODUCTS/download-products.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 DOWNLOAD_LIST=extprods.links.txt
-sufix='-x86_64'
 arch=`uname -m`
 for item in `cat $DOWNLOAD_LIST`; do
         if [[ "$item" == *"eclipse"* ]]

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ ifeq ($(os),Linux)
   ifeq ($(majorRelNo),6)
     GMP =
   endif
+  ubuntuDist:= $(basename $(shell (lsb_release -d | awk '{print $2}')))
+  ifneq (,$(findstring Ubuntu,$(ubuntuDist)))
+   GMP =
+  endif
 endif
 
 MODULES_TOOLS = emacs tat expat loki extjars antlr hibernate extpy cppunit getopt FITS astyle swig xercesc xercesj castor $(GMP) gui xsddoc extidl vtd-xml oAW shunit2 log4cpp scxml_apache


### PR DESCRIPTION
1. Don't compile GMP, using system gmp in Ubuntu Distribution
2. Downloading 32 bits eclipse in i386 and i686 architectures
