### PR TITLE
Fixed Jfree and laser-source-cpp for Ubuntu

### DIFF
--- a/LGPL/CommonSoftware/ACSLaser/laser-source-cpp/src/Makefile
+++ b/LGPL/CommonSoftware/ACSLaser/laser-source-cpp/src/Makefile
@@ -90,7 +90,7 @@ laserSourceAcsSpecific_OBJECTS   = 	CERNASIMessage \
 									AcsAlarmPublisher \
 									AlarmSupplier
 laserSourceAcsSpecific_LIBS = basenc ACSJMSMessageEntityStubs acsnc acsAlSysSource errTypeAlarmService acsutil
-laserSourceAcsSpecific_LDFLAGS = --export-dynamic -dl -fpic
+laserSourceAcsSpecific_LDFLAGS = -rdynamic -dl -fpic
 
 #
 # Scripts (public and local)

--- a/LGPL/Tools/gui/jfree/src/Makefile
+++ b/LGPL/Tools/gui/jfree/src/Makefile
@@ -80,7 +80,7 @@ unpacked:
 #  in jcommon-1.0.10/ant/build.properties. It is used for the javac task in the build.xml file
 #  and would result in a compile error under JDK 1.6.
 #  An alternative would be to remove the "build.target" property by patching the ANT files, or to declare the source as 1.2.
-JDK_VERSION=$(shell java -version 2>&1 | grep 'java version' | cut -d\" -f2 | cut -d. -f1,2)
+JDK_VERSION=$(shell java -version 2>&1 | head -n 1 | cut -d\" -f2 | cut -d. -f1,2)
 jcommon_jar : unpack 
 	@echo ". . . building jcommon . . . "
 	@rm -rf jcommon-$(JCOMMON_VER)/lib


### PR DESCRIPTION
- Changed JDK_VERSION command to a generic one.
- Changed ACSLaser/laser-source-cpp g++ flag from export-dynamic to Unix rdynamic.
